### PR TITLE
Stop item views initializing twice

### DIFF
--- a/marionette.loading.js
+++ b/marionette.loading.js
@@ -40,10 +40,10 @@ _.extend(Marionette.View.prototype, {
 
     setupMarionetteLoading: function () {
         this.__loadingEvents();
-        if (this.renderItemView) {
-            this.renderItemView = function () {
+        if (this.addItemView) {
+            this.addItemView = function () {
                 if (!this.__showingLoadingView) { // add is triggered before sync. if so do not render
-                    Marionette.CompositeView.prototype.renderItemView.apply(this, arguments);
+                    Marionette.CompositeView.prototype.addItemView.apply(this, arguments);
                 }
             }
         }


### PR DESCRIPTION
Any item views in LoadingCollectionViews or LoadingCompositeViews are
initialized twice. This can cause a few issues mostly related to the
creation of ghost item views (the views that are overridden the second
time an item views are initialized).
